### PR TITLE
Add new bootswatch-themes to config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -89,16 +89,21 @@ IMG_UPLOAD_URL = '/static/uploads/'
 # these are located on static/appbuilder/css/themes
 # you can create your own and easily use them placing them on the same dir structure to override
 #APP_THEME = "bootstrap-theme.css"  # default bootstrap
-#APP_THEME = "cerulean.css"
 #APP_THEME = "amelia.css"
+#APP_THEME = "cerulean.css"
 #APP_THEME = "cosmo.css"
-#APP_THEME = "cyborg.css"  
+#APP_THEME = "cyborg.css"
+#APP_THEME = "darkly.css"
 #APP_THEME = "flatly.css"
 #APP_THEME = "journal.css"
+#APP_THEME = "lumen.css"
+#APP_THEME = "paper.css"
 #APP_THEME = "readable.css"
+#APP_THEME = "sandstone.css"
 #APP_THEME = "simplex.css"
-#APP_THEME = "slate.css"   
+#APP_THEME = "slate.css"
+#APP_THEME = "solar.css"
 #APP_THEME = "spacelab.css"
+#APP_THEME = "superhero.css"
 #APP_THEME = "united.css"
 #APP_THEME = "yeti.css"
-


### PR DESCRIPTION
New themes were included in Flask-Appbuilder; see: https://github.com/dpgaspar/Flask-AppBuilder/pull/508.
These are now included here too. The entries are ordered alphabetically except the "default" theme.