### PR TITLE
Update config.py.tpl

### DIFF
--- a/config.py.tpl
+++ b/config.py.tpl
@@ -14,6 +14,7 @@ SECRET_KEY = "{{secret_key}}"
 
 # The SQLAlchemy connection string.
 SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(basedir, "app.db")
+SQLALCHEMY_TRACK_MODIFICATIONS = False
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
 


### PR DESCRIPTION
added SQLALCHEMY_TRACK_MODIFICATIONS = False to stop initial warning when running newly generated app.

1. create a new app using `flask fab create-app` and set database SQLAlchemy, 
2. run the app using `flask run`

The first message to appear is:
[path-to-venv]\Lib\site-packages\flask_sqlalchemy\__init__.py:872: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.

Solution

To fix this, the line has been added to the config.tpl file.